### PR TITLE
deck.gl: Change types of the map layer

### DIFF
--- a/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
+++ b/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
@@ -8,7 +8,7 @@ import { featureCollection as turfFeatureCollection } from '@turf/turf';
 import _uniq from 'lodash/uniq';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { LayerDescription } from './layers/LayerDescription';
+import { MapLayer } from './layers/LayerDescription';
 
 const defaultGeojson = turfFeatureCollection([]) as GeoJSON.FeatureCollection<GeoJSON.Geometry>;
 
@@ -20,7 +20,7 @@ const defaultGeojson = turfFeatureCollection([]) as GeoJSON.FeatureCollection<Ge
  * TODO: If we want to support multiple map implementation, this layer management will have to be updated
  */
 class MapboxLayerManager {
-    private _layersByName: { [key: string]: LayerDescription } = {};
+    private _layersByName: { [key: string]: MapLayer } = {};
     private _enabledLayers: string[] = [];
     private _defaultFilterByLayer = {};
     private _filtersByLayer = {};
@@ -30,7 +30,7 @@ class MapboxLayerManager {
             this._layersByName[layerName] = {
                 id: layerName,
                 visible: false,
-                layerDescription: layersConfig[layerName],
+                configuration: layersConfig[layerName],
                 layerData: defaultGeojson
             };
             this._enabledLayers = [];
@@ -199,7 +199,7 @@ class MapboxLayerManager {
         return this._layersByName[layerName]?.visible;
     }
 
-    getEnabledLayers(): LayerDescription[] {
+    getEnabledLayers(): MapLayer[] {
         return this._enabledLayers.map((layerName) => this._layersByName[layerName]);
     }
 

--- a/packages/chaire-lib-frontend/src/services/map/layers/LayerDescription.ts
+++ b/packages/chaire-lib-frontend/src/services/map/layers/LayerDescription.ts
@@ -5,17 +5,25 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-export type LayerDescription = {
+export type LayerConfiguration = {
+    // TODO Type this properly. When the data in layers.config.ts is used by the new API, add it here
+    [key: string]: any
+};
+
+export type MapLayer = {
     /** Unique identifier for this layer */
     id: string;
-    /** Whether the layer is visible, if enabled */
+    /** 
+     * Whether the layer is visible. The layer visibility is typically defined
+     * by the user. It does not mean it is always visible. It is only visible
+     * when it is enabled by the application.
+     */
     visible: boolean;
     /**
-     * Description of the current layer
-     *
-     * TODO Type this properly
+     * Configuration of the current layer. It should be fixed and not require
+     * updates, except through Preferences if any
      */
-    layerDescription: { [key: string]: any };
+    configuration: LayerConfiguration;
     /** Features contained in this layer */
     layerData: GeoJSON.FeatureCollection<GeoJSON.Geometry>;
 };

--- a/packages/transition-frontend/src/components/map/layers/TransitionMapLayer.tsx
+++ b/packages/transition-frontend/src/components/map/layers/TransitionMapLayer.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { Layer, LayerProps } from '@deck.gl/core/typed';
-import { LayerDescription } from 'chaire-lib-frontend/lib/services/map/layers/LayerDescription';
+import { MapLayer } from 'chaire-lib-frontend/lib/services/map/layers/LayerDescription';
 import { ScatterplotLayer, TripsLayer, PolygonLayer, GeoJsonLayer } from 'deck.gl/typed';
 
 // FIXME default color should probably be a app/user/theme preference?
@@ -18,7 +18,7 @@ const defaultRGBA = [
 ] as [number, number, number, number];
 
 type TransitionMapLayerProps = {
-    layerDescription: LayerDescription;
+    layerDescription: MapLayer;
     // TODO Find the right type for this
     viewState;
 };
@@ -126,15 +126,15 @@ const getLayer = (props: TransitionMapLayerProps): Layer<LayerProps> | undefined
         console.log('layer data is undefined', props.layerDescription.id);
         return undefined;
     }
-    if (props.layerDescription.layerDescription.type === 'circle') {
+    if (props.layerDescription.configuration.type === 'circle') {
         // FIXME Try not to type as any
         return getScatterLayer(props) as any;
-    } else if (props.layerDescription.layerDescription.type === 'line') {
+    } else if (props.layerDescription.configuration.type === 'line') {
         return getLineLayer(props) as any;
-    } else if (props.layerDescription.layerDescription.type === 'fill') {
+    } else if (props.layerDescription.configuration.type === 'fill') {
         return getPolygonLayer(props) as any;
     }
-    console.log('unknown layer', props.layerDescription.layerDescription);
+    console.log('unknown layer', props.layerDescription.configuration);
     return undefined;
 };
 


### PR DESCRIPTION
The type is named `MapLayer` and another type `LayerConfiguration` is used to configure the layer by the application. The configuration is meant to be fixed by the application and does not change, except through Preferences, if necessary.